### PR TITLE
Built Fabric.Pathform.Auth on the correct path

### DIFF
--- a/Fabric.Platform.Bootstrappers.Nancy/Fabric.Platform.Bootstrappers.Nancy.csproj
+++ b/Fabric.Platform.Bootstrappers.Nancy/Fabric.Platform.Bootstrappers.Nancy.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fabric.Platform.Auth" Version="1.0.2018081606" />
+    <PackageReference Include="Fabric.Platform.Auth" Version="1.0.2018081611" />
     <PackageReference Include="Fabric.Platform.Http" Version="1.0.2018040605" />
     <PackageReference Include="Fabric.Platform.Logging" Version="1.0.2018042402" />
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />


### PR DESCRIPTION
I missed what branch the code came from and the previous builds did not have the code changes.

Now I have manually downloaded this nuget and inspected.  It has the code.  I have also manually copied the code over to verify it working.  This should be the last nuget update.